### PR TITLE
Enable Discord login redirect and add logout button style

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 DISCORD_CLIENT_ID=your_client_id
 DISCORD_CLIENT_SECRET=your_client_secret
-DISCORD_CALLBACK_URL=http://localhost:8080/auth/discord/callback
+DISCORD_CALLBACK_URL=http://localhost:3000/auth/discord/callback
 SESSION_SECRET=your_session_secret

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -295,14 +295,25 @@ onMounted(() => {
   color: #e0e0e0;
 }
 
-.login-btn, .logout-btn {
-  background: transparent;
-  border: 1px solid #8A2BE2;
-  color: #e0e0e0;
+
+.login-btn,
+.logout-btn {
   padding: 0.4rem 0.8rem;
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.9rem;
+}
+
+.login-btn {
+  background: transparent;
+  border: 1px solid #8A2BE2;
+  color: #e0e0e0;
+}
+
+.logout-btn {
+  background: #e63946;
+  border: 1px solid #e63946;
+  color: #fff;
 }
 
 .username {


### PR DESCRIPTION
## Summary
- update `.env.example` so the Discord callback matches the server port
- style the logout button in Header component with a red background

## Testing
- `npm run build` *(fails: vue-tsc Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684ca4d019b48325bd3ae4c27eaf90f0