### PR TITLE
Revert broken changes and keep login-only apply link

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc -b && vite build",
+    "build": "node node_modules/vue-tsc/bin/vue-tsc.js -b && node node_modules/vite/bin/vite.js build",
     "preview": "vite preview",
     "start": "node server.js"
   },

--- a/server.js
+++ b/server.js
@@ -38,29 +38,44 @@ passport.deserializeUser((obj, done) => {
   done(null, obj);
 });
 
-passport.use(
-  new DiscordStrategy(
-    {
-      clientID: process.env.DISCORD_CLIENT_ID || '',
-      clientSecret: process.env.DISCORD_CLIENT_SECRET || '',
-      callbackURL: process.env.DISCORD_CALLBACK_URL || '',
-      scope: ['identify']
-    },
-    (_accessToken, _refreshToken, profile, done) => {
-      return done(null, profile);
+const discordEnabled =
+  process.env.DISCORD_CLIENT_ID &&
+  process.env.DISCORD_CLIENT_SECRET &&
+  process.env.DISCORD_CALLBACK_URL;
+
+if (discordEnabled) {
+  passport.use(
+    new DiscordStrategy(
+      {
+        clientID: process.env.DISCORD_CLIENT_ID,
+        clientSecret: process.env.DISCORD_CLIENT_SECRET,
+        callbackURL: process.env.DISCORD_CALLBACK_URL,
+        scope: ['identify']
+      },
+      (_accessToken, _refreshToken, profile, done) => {
+        return done(null, profile);
+      }
+    )
+  );
+
+  app.get('/auth/discord', passport.authenticate('discord'));
+
+  app.get(
+    '/auth/discord/callback',
+    passport.authenticate('discord', { failureRedirect: '/' }),
+    (req, res) => {
+      res.redirect('/');
     }
-  )
-);
-
-app.get('/auth/discord', passport.authenticate('discord'));
-
-app.get(
-  '/auth/discord/callback',
-  passport.authenticate('discord', { failureRedirect: '/' }),
-  (req, res) => {
+  );
+} else {
+  console.warn('Discord OAuth not configured, authentication disabled');
+  app.get('/auth/discord', (_req, res) => {
+    res.status(501).send('OAuth disabled');
+  });
+  app.get('/auth/discord/callback', (_req, res) => {
     res.redirect('/');
-  }
-);
+  });
+}
 
 app.get('/auth/logout', (req, res, next) => {
   req.logout(err => {


### PR DESCRIPTION
## Summary
- revert previous commit that broke the server
- run build tools via Node for consistent permissions
- make Discord OAuth optional so the server starts without credentials

## Testing
- `npm run build`
- `npm start` *(fails: TypeError: OAuth2Strategy requires a clientID option)?

------
https://chatgpt.com/codex/tasks/task_e_684dd2518e108325a13ec0c3f175a759