### PR TITLE
Restrict application duplication

### DIFF
--- a/server.js
+++ b/server.js
@@ -261,6 +261,14 @@ app.post('/api/apply', async (req, res) => {
   // Save application with initial status
   if (req.user) {
     const db = loadDb();
+    const existing = db.applications.find(
+      a => a.userId === req.user.id && a.status !== STATUS.REJECTED
+    );
+    if (existing) {
+      return res
+        .status(400)
+        .json({ success: false, status: existing.status });
+    }
     db.applications.push({
       id: Date.now().toString(),
       userId: req.user.id,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,6 +8,10 @@ import Apply from '../views/Apply.vue'
 import Admin from '../views/Admin.vue'
 import ApplicationStatus from '../views/ApplicationStatus.vue'
 
+const STATUS = {
+  REJECTED: 'Rozpatrzone negatywnie (Napisz nowe podanie w ciągu 24/48h)'
+}
+
 const router = createRouter({
   history: createWebHistory(),
   routes: [
@@ -118,6 +122,14 @@ router.beforeEach(async (to, _from, next) => {
 
   if (to.meta.requiresAuth && (!userData || !userData.user)) {
     return next('/');
+  }
+
+  if (to.path === '/apply') {
+    const statusRes = await fetch('/api/status', { credentials: 'include' });
+    const statusData = await statusRes.json();
+    if (statusData.status && statusData.status !== STATUS.REJECTED) {
+      return next('/status');
+    }
   }
 
   next();

--- a/src/views/ApplicationStatus.vue
+++ b/src/views/ApplicationStatus.vue
@@ -1,6 +1,6 @@
 <template>
   <main class="status-page">
-    <h1>Twoje podanie zostało Wysłane</h1>
+    <h1>{{ headerText }}</h1>
     <h1>Obecny status twojego zgłoszenia: <b><span :class="statusClass">{{ status }}</span></b></h1>
     <p v-if="status === statuses.APPROVED" class="approved-msg">
       Twoje podanie zostało rozpatrzone {{ status }}.
@@ -22,12 +22,16 @@ const statuses = {
 }
 
 const status = ref('')
+const headerText = ref('Twoje podanie zostało Wysłane')
 const discordLink = 'https://discord.gg/your-waiting-room'
 
 onMounted(async () => {
   const res = await fetch('/api/status', { credentials: 'include' })
   const data = await res.json()
   status.value = data.status || ''
+  if (status.value === statuses.APPROVED) {
+    headerText.value = 'Posiadasz już zaakceptowane podanie'
+  }
 })
 
 const statusClass = computed(() => {

--- a/src/views/Apply.vue
+++ b/src/views/Apply.vue
@@ -156,6 +156,13 @@ onMounted(async () => {
     form.value.ooc.discord = `${data.user.username}#${data.user.id}`
   }
 
+  const statusRes = await fetch('/api/status', { credentials: 'include' })
+  const statusData = await statusRes.json()
+  if (statusData.status && statusData.status !== 'Negatywnie (Napisz nowe podanie w ciągu 24/48h)') {
+    router.push('/status')
+    return
+  }
+
   // Odbierz przypisane do użytkownika pytania
   const qRes = await fetch('/api/questions', { credentials: 'include' })
   const qData = await qRes.json()
@@ -174,6 +181,8 @@ async function submitForm() {
   })
   if (response.ok) {
     success.value = true
+    router.push('/status')
+  } else if (response.status === 400) {
     router.push('/status')
   }
 }


### PR DESCRIPTION
## Summary
- check for existing non-rejected application server-side
- redirect from Apply view when user already submitted an application
- block navigation to `/apply` if application is active
- show custom header when application already approved

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684df53266d483258d3ba7d5499b7bf8