### PR TITLE
Add cooldown and history for applications

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -127,7 +127,11 @@ router.beforeEach(async (to, _from, next) => {
   if (to.path === '/apply') {
     const statusRes = await fetch('/api/status', { credentials: 'include' });
     const statusData = await statusRes.json();
-    if (statusData.status && statusData.status !== STATUS.REJECTED) {
+    if (
+      statusData.status &&
+      (statusData.status !== STATUS.REJECTED ||
+        (statusData.reapplyAfter && Date.now() < statusData.reapplyAfter))
+    ) {
       return next('/status');
     }
   }

--- a/src/views/ApplicationStatus.vue
+++ b/src/views/ApplicationStatus.vue
@@ -1,17 +1,49 @@
 <template>
-  <main class="status-page">
-    <h1>{{ headerText }}</h1>
-    <h1>Obecny status twojego zgłoszenia: <b><span :class="statusClass">{{ status }}</span></b></h1>
-    <p v-if="status === statuses.APPROVED" class="approved-msg">
-      Twoje podanie zostało rozpatrzone {{ status }}.
-      <a :href="discordLink" target="_blank">Dołącz na Discorda</a>
-      i zgłoś się w celu dalszej rekrutacji.
-    </p>
+  <main class="status-page" :style="{ backgroundImage: `url(${backgroundImageUrl})` }">
+    <div class="status-overlay"></div>
+    <div class="status-content">
+      <h1>{{ headerText }}</h1>
+      <h1>
+        Obecny status twojego zgłoszenia:
+        <b><span :class="statusClass">{{ status }}</span></b>
+      </h1>
+      <p v-if="status === statuses.APPROVED" class="approved-msg">
+        Twoje podanie zostało rozpatrzone {{ status }}.
+        <a :href="discordLink" target="_blank">Dołącz na Discorda</a>
+        i zgłoś się w celu dalszej rekrutacji.
+      </p>
+
+      <div v-if="status === statuses.REJECTED" class="rejected-box">
+        <p v-if="timeRemaining">
+          W ciągu {{ cooldownHours }}h możesz ponownie złożyć podanie.
+        </p>
+        <button
+          class="reapply-btn"
+          :class="{ ready: !timeRemaining }"
+          @click="gotoApply"
+        >
+          <span v-if="timeRemaining">{{ timeRemaining }}</span>
+          <span v-else>Napisz nowe podanie</span>
+        </button>
+      </div>
+
+      <div v-if="history.length" class="history">
+        <h2>Historia podań</h2>
+        <ul>
+          <li v-for="(h, idx) in history" :key="idx">
+            {{ formatHistory(h) }}
+          </li>
+        </ul>
+      </div>
+    </div>
   </main>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
+import backgroundImage from '../assets/background.jpg'
+
+const backgroundImageUrl = backgroundImage
 
 const statuses = {
   SENT: 'Wysłane',
@@ -24,15 +56,62 @@ const statuses = {
 const status = ref('')
 const headerText = ref('Twoje podanie zostało Wysłane')
 const discordLink = 'https://discord.gg/your-waiting-room'
+const reapplyAfter = ref<number | null>(null)
+const history = ref<any[]>([])
+const timeRemaining = ref('')
+const cooldownHours = ref(0)
+let interval: number | null = null
 
 onMounted(async () => {
   const res = await fetch('/api/status', { credentials: 'include' })
   const data = await res.json()
   status.value = data.status || ''
+  history.value = Array.isArray(data.history) ? data.history : []
+  reapplyAfter.value = data.reapplyAfter || null
+  cooldownHours.value = data.baseCooldownHours || 0
   if (status.value === statuses.APPROVED) {
     headerText.value = 'Posiadasz już zaakceptowane podanie'
   }
+  updateRemaining()
+  if (reapplyAfter.value && Date.now() < reapplyAfter.value) {
+    interval = setInterval(updateRemaining, 1000)
+  }
 })
+
+onUnmounted(() => {
+  if (interval) clearInterval(interval)
+})
+
+function updateRemaining() {
+  if (!reapplyAfter.value) {
+    timeRemaining.value = ''
+    return
+  }
+  const diff = reapplyAfter.value - Date.now()
+  if (diff <= 0) {
+    timeRemaining.value = ''
+    if (interval) {
+      clearInterval(interval)
+      interval = null
+    }
+  } else {
+    const h = Math.floor(diff / 3600000)
+    const m = Math.floor((diff % 3600000) / 60000)
+    const s = Math.floor((diff % 60000) / 1000)
+    timeRemaining.value = `${h}h ${m}m ${s}s`
+  }
+}
+
+function formatHistory(h: any) {
+  const date = new Date(h.timestamp)
+  return `${h.status} - ${date.toLocaleString()}`
+}
+
+function gotoApply() {
+  if (!timeRemaining.value) {
+    window.location.href = '/apply'
+  }
+}
 
 const statusClass = computed(() => {
   switch (status.value) {
@@ -54,8 +133,31 @@ const statusClass = computed(() => {
 
 <style scoped>
 .status-page {
-  padding: 2rem;
+  position: relative;
+  min-height: 80vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.status-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 1;
+}
+
+.status-content {
+  position: relative;
+  z-index: 2;
   text-align: center;
+  padding: 2rem;
 }
 .gray {
   color: gray;
@@ -74,5 +176,26 @@ const statusClass = computed(() => {
 }
 .approved-msg {
   margin-top: 1rem;
+}
+
+.rejected-box {
+  margin-top: 1.5rem;
+}
+
+.reapply-btn {
+  padding: 0.6rem 1.2rem;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  background: #dd0000;
+  cursor: pointer;
+}
+
+.reapply-btn.ready {
+  background: #00aa00;
+}
+
+.history {
+  margin-top: 2rem;
 }
 </style>

--- a/src/views/Apply.vue
+++ b/src/views/Apply.vue
@@ -158,7 +158,11 @@ onMounted(async () => {
 
   const statusRes = await fetch('/api/status', { credentials: 'include' })
   const statusData = await statusRes.json()
-  if (statusData.status && statusData.status !== 'Negatywnie (Napisz nowe podanie w ciągu 24/48h)') {
+  if (
+    statusData.status &&
+    (statusData.status !== 'Negatywnie (Napisz nowe podanie w ciągu 24/48h)' ||
+      (statusData.reapplyAfter && Date.now() < statusData.reapplyAfter))
+  ) {
     router.push('/status')
     return
   }


### PR DESCRIPTION
## Summary
- track rejected application history and cooldown server-side
- expose cooldown info via `/api/status`
- prevent submitting new applications until cooldown expires
- add admin endpoint to change status
- show countdown and history on status page
- block access to application form while cooldown active

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684df9e3c6788325bac7b98996e2f6a9