### PR TITLE
Improve admin application workflow

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,8 +17,8 @@ const STATUS = {
   SENT: 'Wysłane',
   PENDING: 'Przyjęte, oczekuje na rozpatrzenie',
   IN_REVIEW: 'W trakcie rozpatrywania',
-  APPROVED: 'Rozpatrzone Pozytywnie',
-  REJECTED: 'Rozpatrzone negatywnie (Napisz nowe podanie w ciągu 24/48h)'
+  APPROVED: 'Pozytywnie',
+  REJECTED: 'Negatywnie'
 };
 
 // Configurable cooldown settings loaded from config.js
@@ -321,7 +321,13 @@ app.post('/api/apply', async (req, res) => {
       userId: req.user.id,
       data: req.body,
       status: STATUS.SENT,
-      history: [{ status: STATUS.SENT, timestamp: Date.now() }]
+      history: [
+        {
+          status: STATUS.SENT,
+          timestamp: Date.now(),
+          by: req.user.username
+        }
+      ]
     };
     db.applications.push(newApp);
     saveDb(db);
@@ -374,7 +380,7 @@ app.post('/api/admin/status', async (req, res) => {
 
   appEntry.status = status;
   appEntry.history = appEntry.history || [];
-  appEntry.history.push({ status, timestamp: Date.now() });
+  appEntry.history.push({ status, timestamp: Date.now(), by: req.user.username });
 
   if (status === STATUS.REJECTED) {
     appEntry.reapplyAfter = computeReapplyAfter(appEntry.history);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -11,7 +11,7 @@ import AdminApplications from '../views/AdminApplications.vue'
 import AdminApplicationDetail from '../views/AdminApplicationDetail.vue'
 
 const STATUS = {
-  REJECTED: 'Rozpatrzone negatywnie (Napisz nowe podanie w ciągu 24/48h)'
+  REJECTED: 'Negatywnie'
 }
 
 const router = createRouter({

--- a/src/views/AdminApplicationDetail.vue
+++ b/src/views/AdminApplicationDetail.vue
@@ -4,7 +4,7 @@
       <i class="fa-solid fa-arrow-left"></i> Powrót
     </RouterLink>
     <div v-if="app" class="detail-container">
-      <h1 class="detail-title">Podanie użytkownika {{ cleanDiscord(app.data.ooc.discord) }}</h1>
+      <h1 class="detail-title">Podanie użytkownika <span class="logo-accent discord-name">{{ cleanDiscord(app.data.ooc.discord) }}</span></h1>
       <table class="app-table">
         <tr>
           <th>Status</th>
@@ -13,6 +13,10 @@
         <tr>
           <th>Data zgłoszenia</th>
           <td>{{ formatDate(ts) }}</td>
+        </tr>
+        <tr v-if="decisionInfo">
+          <th>Decyzja</th>
+          <td>{{ decisionInfo }}</td>
         </tr>
       </table>
       <h2>Informacje IC</h2>
@@ -39,16 +43,29 @@
       </table>
       <h2>Pytania sytuacyjne</h2>
       <table class="app-table">
-        <tr v-for="(qa, idx) in scenarioPairs" :key="idx">
-          <th>{{ qa.question }}</th>
-          <td>{{ qa.answer }}</td>
-        </tr>
+        <template v-for="(qa, idx) in scenarioPairs" :key="idx">
+          <tr>
+            <th colspan="2" class="question-cell">{{ qa.question }}</th>
+          </tr>
+          <tr>
+            <td colspan="2" class="answer-cell">{{ qa.answer }}</td>
+          </tr>
+        </template>
       </table>
       <h2>Dodatkowo</h2>
       <table class="app-table">
         <tr><th>Portfolio</th><td>{{ app.data.extra.portfolio }}</td></tr>
         <tr><th>Frakcja</th><td>{{ app.data.extra.faction }}</td></tr>
       </table>
+      <div class="decision-box">
+        <label for="status-select">Decyzja</label>
+        <select id="status-select" v-model="selectedStatus">
+          <option v-for="(label, key) in decisionOptions" :key="key" :value="label">
+            {{ label }}
+          </option>
+        </select>
+        <button @click="updateStatus" class="update-btn">Zmień status</button>
+      </div>
     </div>
     <p v-else>Ładowanie...</p>
   </main>
@@ -60,19 +77,49 @@ import { useRoute, RouterLink } from 'vue-router'
 
 interface Application {
   id: string
+  userId: string
   status: string
   data: any
-  history?: { status: string; timestamp: number }[]
+  history?: { status: string; timestamp: number; by?: string }[]
 }
 
 const route = useRoute()
 const app = ref<Application | null>(null)
+const currentUser = ref<any>(null)
+const selectedStatus = ref('')
+
+const statuses = {
+  SENT: 'Wysłane',
+  PENDING: 'Przyjęte, oczekuje na rozpatrzenie',
+  IN_REVIEW: 'W trakcie rozpatrywania',
+  APPROVED: 'Pozytywnie',
+  REJECTED: 'Negatywnie'
+}
+
+const decisionOptions = {
+  PENDING: statuses.PENDING,
+  IN_REVIEW: statuses.IN_REVIEW,
+  APPROVED: statuses.APPROVED,
+  REJECTED: statuses.REJECTED
+}
 
 onMounted(async () => {
+  const userRes = await fetch('/api/user', { credentials: 'include' })
+  if (userRes.ok) {
+    const userData = await userRes.json()
+    currentUser.value = userData.user
+  }
   const res = await fetch(`/api/admin/applications/${route.params.id}`, { credentials: 'include' })
   if (res.ok) {
     const data = await res.json()
     app.value = data.application || null
+    if (app.value) {
+      selectedStatus.value = app.value.status
+      if (app.value.status === statuses.SENT) {
+        await updateStatusInternal(statuses.PENDING)
+        selectedStatus.value = statuses.PENDING
+      }
+    }
   }
 })
 
@@ -91,14 +138,16 @@ const scenarioPairs = computed(() => {
 const statusClass = computed(() => {
   if (!app.value) return ''
   switch (app.value.status) {
-    case 'Wysłane':
+    case statuses.SENT:
       return 'gray'
-    case 'Przyjęte, oczekuje na rozpatrzenie':
+    case statuses.PENDING:
       return 'orange'
-    case 'W trakcie rozpatrywania':
+    case statuses.IN_REVIEW:
       return 'blue'
+    case statuses.APPROVED:
     case 'Rozpatrzone Pozytywnie':
       return 'green'
+    case statuses.REJECTED:
     case 'Rozpatrzone negatywnie (Napisz nowe podanie w ciągu 24/48h)':
       return 'red'
     default:
@@ -114,6 +163,40 @@ function formatDate(t: number) {
 function cleanDiscord(d: string) {
   return d.split('#')[0]
 }
+
+async function updateStatusInternal(newStatus: string) {
+  if (!app.value) return
+  await fetch('/api/admin/status', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ userId: app.value.userId, status: newStatus })
+  })
+  app.value.status = newStatus
+  if (!app.value.history) app.value.history = []
+  app.value.history.push({
+    status: newStatus,
+    timestamp: Date.now(),
+    by: currentUser.value?.username || 'Admin'
+  })
+}
+
+function updateStatus() {
+  if (!selectedStatus.value || !app.value) return
+  if (selectedStatus.value !== app.value.status) {
+    updateStatusInternal(selectedStatus.value)
+  }
+}
+
+const decisionInfo = computed(() => {
+  if (!app.value || !app.value.history) return ''
+  const latest = [...app.value.history]
+    .reverse()
+    .find(h => h.status === statuses.APPROVED || h.status === statuses.REJECTED)
+  if (!latest) return ''
+  const date = new Date(latest.timestamp).toLocaleString()
+  return `${latest.status} przez ${latest.by || 'Admin'} - ${date}`
+})
 </script>
 
 <style scoped>
@@ -129,7 +212,11 @@ function cleanDiscord(d: string) {
   align-items: center;
   gap: 0.3rem;
   margin-bottom: 1rem;
+  padding: 0.3rem 0.6rem;
   color: #fff;
+  background: var(--gradient-accent);
+  border-radius: 4px;
+  text-decoration: none;
 }
 
 .detail-title {
@@ -139,10 +226,7 @@ function cleanDiscord(d: string) {
 }
 
 .status-text {
-  background: linear-gradient(90deg, #8A2BE2, #00FFFF);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  font-weight: bold;
 }
 
 .detail-container {
@@ -154,12 +238,15 @@ function cleanDiscord(d: string) {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 1rem;
+  background: rgba(255, 255, 255, 0.05);
 }
 .app-table th,
 .app-table td {
   border: 1px solid rgba(255, 255, 255, 0.2);
   padding: 0.5rem;
   vertical-align: top;
+  word-wrap: break-word;
+  white-space: pre-wrap;
 }
 .gray {
   color: gray;
@@ -175,5 +262,31 @@ function cleanDiscord(d: string) {
 }
 .red {
   color: #dd0000;
+}
+
+.decision-box {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.update-btn {
+  padding: 0.4rem 0.8rem;
+  border: 1px solid transparent;
+  background: var(--gradient-accent);
+  color: #fff;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+
+.question-cell {
+  font-weight: 600;
+}
+
+.answer-cell {
+  white-space: pre-wrap;
 }
 </style>

--- a/src/views/AdminApplications.vue
+++ b/src/views/AdminApplications.vue
@@ -17,9 +17,9 @@
           <p class="app-time"><b>Data:</b> {{ formatDate(app.timestamp) }}</p>
           <p class="app-status"><b>Status:</b> <span :class="['status-text', statusClass(app.status)]">{{ app.status }}</span></p>
           <p class="app-number"><b>Numer:</b> {{ app.number }}</p>
-          <RouterLink :to="`/admin/applications/${app.id}`" class="preview-btn">
+          <button class="preview-btn" @click="openDetail(app)">
             <i class="fa-solid fa-eye"></i> Podgląd
-          </RouterLink>
+          </button>
         </div>
       </div>
     </div>
@@ -28,7 +28,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { RouterLink } from 'vue-router'
+import { useRouter } from 'vue-router'
 
 interface Application {
   id: string
@@ -40,6 +40,7 @@ interface Application {
 }
 
 const applications = ref<Application[]>([])
+const router = useRouter()
 
 onMounted(async () => {
   const res = await fetch('/api/admin/applications', {
@@ -92,12 +93,27 @@ function statusClass(status: string) {
     case statuses.IN_REVIEW:
       return 'blue'
     case statuses.APPROVED:
+    case 'Rozpatrzone Pozytywnie':
       return 'green'
     case statuses.REJECTED:
+    case 'Rozpatrzone negatywnie (Napisz nowe podanie w ciągu 24/48h)':
       return 'red'
     default:
       return ''
   }
+}
+
+async function openDetail(app: Application) {
+  if (app.status === statuses.SENT) {
+    await fetch('/api/admin/status', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ userId: app.userId, status: statuses.PENDING })
+    })
+    app.status = statuses.PENDING
+  }
+  router.push(`/admin/applications/${app.id}`)
 }
 </script>
 
@@ -156,6 +172,8 @@ function statusClass(status: string) {
   padding: 0.75rem;
   margin-bottom: 0.75rem;
   font-size: 0.9rem;
+  display: flex;
+  flex-direction: column;
 }
 
 .app-card p {
@@ -163,10 +181,7 @@ function statusClass(status: string) {
 }
 
 .status-text {
-  background: linear-gradient(90deg, #8A2BE2, #00FFFF);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  font-weight: bold;
 }
 .gray {
   color: gray;
@@ -187,14 +202,16 @@ function statusClass(status: string) {
 .preview-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.3rem;
-  margin-top: 0.4rem;
+  margin-top: auto;
   font-size: 0.85rem;
   color: #fff;
   background: rgba(138, 43, 226, 0.3);
   padding: 0.3rem 0.6rem;
   border-radius: 6px;
   transition: background 0.2s ease;
+  align-self: center;
 }
 
 .preview-btn:hover {

--- a/src/views/ApplicationStatus.vue
+++ b/src/views/ApplicationStatus.vue
@@ -73,7 +73,7 @@ const statuses = {
   PENDING: 'Przyjęte, oczekuje na rozpatrzenie',
   IN_REVIEW: 'W trakcie rozpatrywania',
   APPROVED: 'Pozytywnie',
-  REJECTED: 'Negatywnie (Napisz nowe podanie w ciągu 24/48h)'
+  REJECTED: 'Negatywnie'
 }
 
 const joinSteps = ref([

--- a/src/views/Apply.vue
+++ b/src/views/Apply.vue
@@ -163,7 +163,7 @@ onMounted(async () => {
   const statusData = await statusRes.json()
   if (
     statusData.status &&
-    (statusData.status !== 'Negatywnie (Napisz nowe podanie w ciągu 24/48h)' ||
+    (statusData.status !== 'Negatywnie' ||
       (statusData.reapplyAfter && Date.now() < statusData.reapplyAfter))
   ) {
     router.push('/status')


### PR DESCRIPTION
## Summary
- change status storage to track who made updates
- move preview button and fix colors in admin application list
- auto-update application to pending when previewed
- redesign admin detail view and allow changing status
- fix status labels and decision layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f490ecd9c8325b03961e37550c392