### PR TITLE
Handle negative status removal

### DIFF
--- a/server.js
+++ b/server.js
@@ -415,6 +415,12 @@ app.post('/api/admin/status', async (req, res) => {
     appEntry.history.push(entry);
   }
 
+  if (status === STATUS.APPROVED) {
+    appEntry.history = appEntry.history.filter(
+      h => normalizeStatus(h.status) !== STATUS.REJECTED
+    );
+  }
+
   if (status === STATUS.REJECTED) {
     appEntry.reapplyAfter = computeReapplyAfter(appEntry.history);
   } else {

--- a/src/views/AdminApplicationDetail.vue
+++ b/src/views/AdminApplicationDetail.vue
@@ -175,11 +175,22 @@ async function updateStatusInternal(newStatus: string) {
   })
   app.value.status = newStatus
   if (!app.value.history) app.value.history = []
-  app.value.history.push({
+  const idx = app.value.history.findIndex(h => h.status === newStatus)
+  const entry = {
     status: newStatus,
     timestamp: Date.now(),
     by: currentUser.value?.username || 'Admin'
-  })
+  }
+  if (idx >= 0) {
+    app.value.history[idx] = entry
+  } else {
+    app.value.history.push(entry)
+  }
+  if (newStatus === statuses.APPROVED) {
+    app.value.history = app.value.history.filter(
+      h => h.status !== statuses.REJECTED
+    )
+  }
 }
 
 function updateStatus() {


### PR DESCRIPTION
## Summary
- remove rejected entries from history when an application is approved
- mirror this logic in the admin UI

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f58ef0244832597fb19690055539f