### PR TITLE
Limit archive button visibility and add restore option

### DIFF
--- a/src/views/AdminApplications.vue
+++ b/src/views/AdminApplications.vue
@@ -26,12 +26,8 @@
             :class="['app-card', { highlight: isHighlighted(app, col.key) }]"
           >
           <button
-<<<<<<< sii9i8-codex/przenieść-przycisk-archiwizuj-i-zmienić-status
             v-if="!app.archived &&
               (app.status === statuses.APPROVED || app.status === statuses.REJECTED)"
-=======
-            v-if="!app.archived"
->>>>>>> main
             class="archive-btn top-right"
             @click="archiveApplication(app)"
           >


### PR DESCRIPTION
## Summary
- show archive button only for approved and rejected applications
- remove archived info row and add restore option to application detail
- allow admins to unarchive applications via new API route

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68505d712ddc832582f1413f28f22fb6