### PR TITLE
Separate admin application lists by type

### DIFF
--- a/server.js
+++ b/server.js
@@ -543,8 +543,12 @@ app.get('/api/admin/applications', async (req, res) => {
   }
 
   const db = loadDb();
+  const type = req.query.type || 'whitelist';
   autoArchiveOldApplications(db);
-  const sorted = db.applications
+  const filteredApps = db.applications.filter(
+    a => (a.type || 'whitelist') === type
+  );
+  const sorted = filteredApps
     .map(a => ({
       ...a,
       ts: a.history && a.history[0] ? a.history[0].timestamp : Number(a.id)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -202,7 +202,48 @@ const router = createRouter({
       component: AdminApplications,
       meta: {
         title: 'Lista Podań - AetherRP',
-        requiresAuth: true
+        requiresAuth: true,
+        type: 'whitelist'
+      }
+    },
+    {
+      path: '/admin/checker-applications',
+      name: 'checker-applications',
+      component: AdminApplications,
+      meta: {
+        title: 'Lista Podań Checkerów - AetherRP',
+        requiresAuth: true,
+        type: 'checker'
+      }
+    },
+    {
+      path: '/admin/moderator-applications',
+      name: 'moderator-applications',
+      component: AdminApplications,
+      meta: {
+        title: 'Lista Podań Moderatorów - AetherRP',
+        requiresAuth: true,
+        type: 'moderator'
+      }
+    },
+    {
+      path: '/admin/administrator-applications',
+      name: 'administrator-applications',
+      component: AdminApplications,
+      meta: {
+        title: 'Lista Podań Administratorów - AetherRP',
+        requiresAuth: true,
+        type: 'administrator'
+      }
+    },
+    {
+      path: '/admin/developer-applications',
+      name: 'developer-applications',
+      component: AdminApplications,
+      meta: {
+        title: 'Lista Podań Developerów - AetherRP',
+        requiresAuth: true,
+        type: 'developer'
       }
     },
     {

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -11,22 +11,38 @@
           <i class="fa-solid fa-clipboard-check"></i>
           <span>Sprawdź podania na WhiteListe</span>
         </RouterLink>
-        <div class="admin-section" v-if="canViewWhitelistChecker">
+        <RouterLink
+          class="admin-section"
+          v-if="canViewWhitelistChecker"
+          to="/admin/checker-applications"
+        >
           <i class="fa-solid fa-user-check"></i>
           <span>Sprawdź podania na WhiteListCheckera</span>
-        </div>
-        <div class="admin-section" v-if="canViewModerator">
+        </RouterLink>
+        <RouterLink
+          class="admin-section"
+          v-if="canViewModerator"
+          to="/admin/moderator-applications"
+        >
           <i class="fa-solid fa-shield"></i>
           <span>Sprawdź podania na Moderatora</span>
-        </div>
-        <div class="admin-section" v-if="canViewAdministrator">
+        </RouterLink>
+        <RouterLink
+          class="admin-section"
+          v-if="canViewAdministrator"
+          to="/admin/administrator-applications"
+        >
           <i class="fa-solid fa-user-shield"></i>
           <span>Sprawdź podania na Administratora</span>
-        </div>
-        <div class="admin-section" v-if="canViewDeveloper">
+        </RouterLink>
+        <RouterLink
+          class="admin-section"
+          v-if="canViewDeveloper"
+          to="/admin/developer-applications"
+        >
           <i class="fa-solid fa-code"></i>
           <span>Sprawdź podania na Developera</span>
-        </div>
+        </RouterLink>
         <RouterLink class="admin-section" to="/admin/player-notes">
           <i class="fa-solid fa-note-sticky"></i>
           <span>Notatki o graczach</span>

--- a/src/views/AdminApplications.vue
+++ b/src/views/AdminApplications.vue
@@ -79,9 +79,11 @@ interface Application {
 
 const applications = ref<Application[]>([])
 const router = useRouter()
+const route = useRoute()
+const appType = computed(() => (route.meta.type as string) || 'whitelist')
 
 onMounted(async () => {
-  const res = await fetch('/api/admin/applications', {
+  const res = await fetch(`/api/admin/applications?type=${appType.value}`, {
     credentials: 'include'
   })
   if (res.ok) {
@@ -98,7 +100,6 @@ const statuses = {
   REJECTED: 'Negatywnie',
   ARCHIVED: 'Zarchiwizowane'
 }
-const route = useRoute()
 const showArchivedOnly = computed(() => route.path.includes('archived'))
 
 const columns = computed<{ key: keyof typeof statuses; label: string }[]>(() =>


### PR DESCRIPTION
## Summary
- filter admin application list endpoint by type
- fetch applications by type in admin list view
- add routes for each application type
- update admin panel links to point to the new routes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68509a2e4e1c8325a4b0e6bfddfb7f0d