### PR TITLE
Extend review workflow for checker and developer

### DIFF
--- a/server.js
+++ b/server.js
@@ -351,7 +351,10 @@ app.get('/api/status', (req, res) => {
     archived: appEntry ? appEntry.archived || null : null,
     reapplyAfter: appEntry ? appEntry.reapplyAfter || null : null,
     baseCooldownHours:
-      type === 'administrator' || type === 'moderator'
+      type === 'administrator' ||
+      type === 'moderator' ||
+      type === 'checker' ||
+      type === 'developer'
         ? ADMIN_REAPPLY_COOLDOWN_DAYS * 24
         : REAPPLY_COOLDOWN_HOURS,
     extraCooldownHours: EXTRA_COOLDOWN_HOURS,
@@ -519,7 +522,10 @@ app.post('/api/admin/status', async (req, res) => {
 
   if (status === STATUS.REJECTED) {
     const base =
-      appEntry.type === 'administrator' || appEntry.type === 'moderator'
+      appEntry.type === 'administrator' ||
+      appEntry.type === 'moderator' ||
+      appEntry.type === 'checker' ||
+      appEntry.type === 'developer'
         ? ADMIN_REAPPLY_COOLDOWN_DAYS * 24
         : REAPPLY_COOLDOWN_HOURS;
     appEntry.reapplyAfter = computeReapplyAfter(appEntry.history, base);

--- a/src/views/AdminApplicationDetail.vue
+++ b/src/views/AdminApplicationDetail.vue
@@ -79,6 +79,56 @@
         </table>
         <h2>Zgody</h2>
         <table class="app-table">
+        <tr><th>Dane</th><td>{{ app.data.consentData ? 'Tak' : 'Nie' }}</td></tr>
+        <tr><th>Obowiązki</th><td>{{ app.data.consentDuties ? 'Tak' : 'Nie' }}</td></tr>
+        <tr><th>Prawdziwość</th><td>{{ app.data.consentTruth ? 'Tak' : 'Nie' }}</td></tr>
+      </table>
+      </template>
+      <template v-else-if="app.type === 'checker'">
+        <h2>Informacje OOC</h2>
+        <table class="app-table">
+          <tr><th>Discord</th><td>{{ discordField }}</td></tr>
+          <tr><th>Od kiedy na serwerze</th><td>{{ app.data.serverTime }}</td></tr>
+        </table>
+        <h2>Doświadczenie i podejście</h2>
+        <table class="app-table">
+          <tr><th>Doświadczenie w weryfikacji</th><td>{{ app.data.verificationExp }}</td></tr>
+          <tr><th>Rozpoznawanie kandydatów</th><td>{{ app.data.differentiate }}</td></tr>
+          <tr><th>Na co zwracasz uwagę</th><td>{{ app.data.reviewFocus }}</td></tr>
+          <tr><th>Dobre RP</th><td>{{ app.data.goodRp }}</td></tr>
+        </table>
+        <h2>Praca</h2>
+        <table class="app-table">
+          <tr><th>Możliwa liczba podań</th><td>{{ app.data.workload }}</td></tr>
+          <tr><th>Wątpliwości co do kandydata</th><td>{{ app.data.doubts }}</td></tr>
+          <tr><th>Praca w zespole</th><td>{{ app.data.teamwork }}</td></tr>
+        </table>
+        <h2>Zgody</h2>
+        <table class="app-table">
+          <tr><th>Dane</th><td>{{ app.data.consentData ? 'Tak' : 'Nie' }}</td></tr>
+          <tr><th>Obowiązki</th><td>{{ app.data.consentDuties ? 'Tak' : 'Nie' }}</td></tr>
+          <tr><th>Prawdziwość</th><td>{{ app.data.consentTruth ? 'Tak' : 'Nie' }}</td></tr>
+        </table>
+      </template>
+      <template v-else-if="app.type === 'developer'">
+        <h2>Informacje OOC</h2>
+        <table class="app-table">
+          <tr><th>Discord</th><td>{{ discordField }}</td></tr>
+        </table>
+        <h2>Doświadczenie i umiejętności</h2>
+        <table class="app-table">
+          <tr><th>Języki programowania</th><td>{{ app.data.languages }}</td></tr>
+          <tr><th>Doświadczenie z FiveM</th><td>{{ app.data.fivemExp }}</td></tr>
+          <tr><th>Organizacja pracy</th><td>{{ app.data.workOrg }}</td></tr>
+          <tr><th>Najlepszy projekt</th><td>{{ app.data.proudProject }}</td></tr>
+          <tr><th>Reakcja na błąd</th><td>{{ app.data.bugResponse }}</td></tr>
+          <tr><th>Kodowanie pod wymagania</th><td>{{ app.data.requirements }}</td></tr>
+          <tr><th>Zainteresowania</th><td>{{ app.data.interests }}</td></tr>
+          <tr><th>Testowanie</th><td>{{ app.data.testing }}</td></tr>
+          <tr><th>Portfolio</th><td>{{ app.data.portfolio }}</td></tr>
+        </table>
+        <h2>Zgody</h2>
+        <table class="app-table">
           <tr><th>Dane</th><td>{{ app.data.consentData ? 'Tak' : 'Nie' }}</td></tr>
           <tr><th>Obowiązki</th><td>{{ app.data.consentDuties ? 'Tak' : 'Nie' }}</td></tr>
           <tr><th>Prawdziwość</th><td>{{ app.data.consentTruth ? 'Tak' : 'Nie' }}</td></tr>

--- a/src/views/AdminApplications.vue
+++ b/src/views/AdminApplications.vue
@@ -37,6 +37,18 @@
           >
             Podanie Moderatora
           </p>
+          <p
+            v-else-if="showArchivedOnly && app.type === 'checker'"
+            class="app-type"
+          >
+            Podanie WhiteListCheckera
+          </p>
+          <p
+            v-else-if="showArchivedOnly && app.type === 'developer'"
+            class="app-type"
+          >
+            Podanie Developera
+          </p>
           <button
             v-if="!app.archived &&
               (app.status === statuses.APPROVED || app.status === statuses.REJECTED)"

--- a/src/views/ApplicationStatus.vue
+++ b/src/views/ApplicationStatus.vue
@@ -196,7 +196,10 @@ const rejectedHistory = computed(() =>
   history.value.filter(h => h.status === statuses.REJECTED)
 )
 const cooldownText = computed(() =>
-  appType.value === 'administrator' || appType.value === 'moderator'
+  appType.value === 'administrator' ||
+  appType.value === 'moderator' ||
+  appType.value === 'checker' ||
+  appType.value === 'developer'
     ? `${Math.round(cooldownHours.value / 24)} dni`
     : `${cooldownHours.value}h`
 )
@@ -225,7 +228,11 @@ onMounted(async () => {
         ? 'Twoje podanie na Administratora zostało wysłane'
         : appType.value === 'moderator'
           ? 'Twoje podanie na Moderatora zostało wysłane'
-          : 'Twoje podanie zostało Wysłane'
+          : appType.value === 'checker'
+            ? 'Twoje podanie na WhiteListCheckera zostało wysłane'
+            : appType.value === 'developer'
+              ? 'Twoje podanie na Developera zostało wysłane'
+              : 'Twoje podanie zostało Wysłane'
   }
   updateRemaining()
   if (reapplyAfter.value && Date.now() < reapplyAfter.value) {


### PR DESCRIPTION
## Summary
- include WhiteListChecker/Developer types when computing rejection cooldowns
- display correct headings for checker/developer in application status
- show application type for archived checker and developer submissions
- add admin detail views for checker and developer questions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851ae7db86083259446d4917c0ec07d