### PR TITLE
Show full application text

### DIFF
--- a/src/views/AdminApplicationDetail.vue
+++ b/src/views/AdminApplicationDetail.vue
@@ -625,9 +625,11 @@ const decisionInfo = computed(() => {
 
 .question-cell {
   font-weight: 600;
+  white-space: pre-wrap;
 }
 
 .answer-cell {
   white-space: pre-wrap;
+  word-break: break-word;
 }
 </style>


### PR DESCRIPTION
## Summary
- ensure `AdminApplicationDetail` uses `white-space: pre-wrap` for question and answer cells so preview shows full text

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851cc87694083259969956296d17cd1