### PR TITLE
Fix application numbering by submission type

### DIFF
--- a/server.js
+++ b/server.js
@@ -584,14 +584,15 @@ app.get('/api/admin/applications', async (req, res) => {
 
   const counts = {};
   const result = sorted.map(a => {
-    counts[a.userId] = (counts[a.userId] || 0) + 1;
+    const typeKey = `${a.userId}:${a.type || 'whitelist'}`;
+    counts[typeKey] = (counts[typeKey] || 0) + 1;
     return {
       id: a.id,
       userId: a.userId,
       discord: a.data?.ooc?.discord || a.data?.discord || '',
       status: a.status,
       timestamp: a.ts,
-      number: counts[a.userId],
+      number: counts[typeKey],
       archived: a.archived || null,
       type: a.type || 'whitelist'
     };


### PR DESCRIPTION
## Summary
- count application numbers per user and submission type

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851e572a6e483258cb32035cc421228