### PR TITLE
Add unban request flow

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -15,7 +15,14 @@
           <li><router-link to="/staff" class="nav-link" active-class="active"><i class="fa-solid fa-users"></i> Zespół</router-link></li>
           <li><router-link to="/rules" class="nav-link" active-class="active"><i class="fa-solid fa-file-contract"></i> Zasady</router-link></li>
           <li><router-link to="/join" class="nav-link" active-class="active"><i class="fa-solid fa-book"></i> Jak dołączyć</router-link></li>
-          <li v-if="isLoggedIn"><router-link to="/applications" class="nav-link" active-class="active"><i class="fa-solid fa-file-signature"></i> Złóż podanie</router-link></li>
+          <li v-if="isLoggedIn" class="dropdown-wrapper">
+            <router-link to="/applications" class="nav-link" active-class="active"><i class="fa-solid fa-file-signature"></i> Złóż podanie</router-link>
+            <ul class="dropdown">
+              <li>
+                <router-link to="/apply-unban" class="dropdown-link"><span class="emoji">📝</span> Odwołanie od bana</router-link>
+              </li>
+            </ul>
+          </li>
         </ul>
       </nav>
       <div class="header-actions">
@@ -47,6 +54,7 @@
         <li><router-link to="/rules" @click="closeMenu"><i class="fa-solid fa-file-contract"></i> Zasady</router-link></li>
         <li><router-link to="/join" @click="closeMenu"><i class="fa-solid fa-book"></i> Jak dołączyć</router-link></li>
         <li v-if="isLoggedIn"><router-link to="/applications" @click="closeMenu"><i class="fa-solid fa-file-signature"></i> Złóż podanie</router-link></li>
+        <li v-if="isLoggedIn"><router-link to="/apply-unban" @click="closeMenu"><i class="fa-solid fa-ban"></i> Odwołanie od bana</router-link></li>
         <li v-if="isAdmin"><router-link to="/admin" @click="closeMenu"><i class="fa-solid fa-screwdriver-wrench"></i> Administrowanie</router-link></li>
       </ul>
       <div class="mobile-social-icons">
@@ -275,6 +283,43 @@ onMounted(() => {
 .nav-link:hover::after,
 .nav-link.active::after {
   width: 100%;
+}
+
+.dropdown-wrapper {
+  position: relative;
+}
+
+.dropdown {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+  background: rgba(18, 18, 18, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  min-width: 180px;
+  z-index: 100;
+}
+
+.dropdown-wrapper:hover .dropdown {
+  display: block;
+}
+
+.dropdown-link {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.8rem;
+  color: #e0e0e0;
+  white-space: nowrap;
+}
+
+.dropdown-link:hover {
+  background: rgba(138, 43, 226, 0.2);
+  color: #fff;
 }
 
 .header-actions {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -138,6 +138,15 @@ const router = createRouter({
       }
     },
     {
+      path: '/apply-unban',
+      name: 'apply-unban',
+      component: () => import('../views/ApplyUnban.vue'),
+      meta: {
+        title: 'Odwołanie od bana - AetherRP',
+        requiresAuth: true,
+      }
+    },
+    {
       path: '/status',
       name: 'status',
       component: ApplicationStatus,
@@ -184,6 +193,16 @@ const router = createRouter({
         title: 'Status Podania Developera - AetherRP',
         requiresAuth: true,
         type: 'developer'
+      }
+    },
+    {
+      path: '/status-unban',
+      name: 'status-unban',
+      component: ApplicationStatus,
+      meta: {
+        title: 'Status Wniosku o odbanowanie - AetherRP',
+        requiresAuth: true,
+        type: 'unban'
       }
     },
     {
@@ -247,6 +266,16 @@ const router = createRouter({
       }
     },
     {
+      path: '/admin/unban',
+      name: 'unban-applications',
+      component: AdminApplications,
+      meta: {
+        title: 'Wnioski o Odbanowanie - AetherRP',
+        requiresAuth: true,
+        type: 'unban'
+      }
+    },
+    {
       path: '/admin/archived',
       name: 'archived-applications',
       component: AdminApplications,
@@ -307,6 +336,16 @@ const router = createRouter({
       }
     },
     {
+      path: '/admin/unban/:id',
+      name: 'unban-detail',
+      component: AdminApplicationDetail,
+      meta: {
+        title: 'Wniosek o odbanowanie - AetherRP',
+        requiresAuth: true,
+        type: 'unban'
+      }
+    },
+    {
       path: '/admin/player-notes',
       name: 'player-notes',
       component: AdminPlayerNotes,
@@ -352,7 +391,8 @@ router.beforeEach(async (to, _from, next) => {
       type: 'administrator',
       statusPath: '/status-administrator'
     },
-    '/apply-developer': { type: 'developer', statusPath: '/status-developer' }
+    '/apply-developer': { type: 'developer', statusPath: '/status-developer' },
+    '/apply-unban': { type: 'unban', statusPath: '/status-unban' }
   };
   if (applyRoutes[to.path]) {
     const { type, statusPath } = applyRoutes[to.path];

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -56,8 +56,8 @@
       </div>
       <div class="admin-extra">
         <RouterLink class="admin-section" to="/admin/unban">
-          <i class="fa-solid fa-box-archive"></i>
-          <span>Wnioski o odbanowanie (W trakcie pracy)</span>
+          <i class="fa-solid fa-ban"></i>
+          <span>Wnioski o odbanowanie</span>
         </RouterLink>
       </div>
     </div>

--- a/src/views/AdminApplicationDetail.vue
+++ b/src/views/AdminApplicationDetail.vue
@@ -320,14 +320,49 @@
             <th>Zgoda na przetwarzanie danych (Discord ID)</th>
             <td>{{ app.data.consentData ? 'Tak' : 'Nie' }}</td>
           </tr>
-          <tr>
-            <th>Akceptuję zakres obowiązków Developera</th>
-            <td>{{ app.data.consentDuties ? 'Tak' : 'Nie' }}</td>
-          </tr>
-          <tr>
-            <th>Potwierdzam prawdziwość podanych informacji</th>
-            <td>{{ app.data.consentTruth ? 'Tak' : 'Nie' }}</td>
-          </tr>
+        <tr>
+          <th>Akceptuję zakres obowiązków Developera</th>
+          <td>{{ app.data.consentDuties ? 'Tak' : 'Nie' }}</td>
+        </tr>
+        <tr>
+          <th>Potwierdzam prawdziwość podanych informacji</th>
+          <td>{{ app.data.consentTruth ? 'Tak' : 'Nie' }}</td>
+        </tr>
+      </table>
+      </template>
+      <template v-else-if="app.type === 'unban'">
+        <h2>Dane Gracza</h2>
+        <table class="app-table">
+          <tr><th>Nick Discord + ID</th><td>{{ discordField }}</td></tr>
+          <tr><th>SteamID</th><td>{{ app.data.steamId }}</td></tr>
+          <tr><th>Nick w momencie bana</th><td>{{ app.data.serverNick }}</td></tr>
+          <tr><th>Data bana</th><td>{{ app.data.banDate }}</td></tr>
+        </table>
+        <h2>Szczegóły Bana</h2>
+        <table class="app-table">
+          <tr><th>Kto nałożył bana</th><td>{{ app.data.bannedBy }}</td></tr>
+          <tr><th>Powód bana</th><td>{{ app.data.banReason }}</td></tr>
+        </table>
+        <h2>Wyjaśnienie</h2>
+        <table class="app-table">
+          <tr><th colspan="2" class="question-cell">Twoja wersja wydarzeń</th></tr>
+          <tr><td colspan="2" class="answer-cell">{{ app.data.events }}</td></tr>
+          <tr><th colspan="2" class="question-cell">Czy przyznajesz się do złamania zasad?</th></tr>
+          <tr><td colspan="2" class="answer-cell">{{ app.data.admit }}</td></tr>
+          <tr><th colspan="2" class="question-cell">Co zmieniło się od momentu bana?</th></tr>
+          <tr><td colspan="2" class="answer-cell">{{ app.data.change }}</td></tr>
+        </table>
+        <h2>Dodatki</h2>
+        <table class="app-table">
+          <tr><th colspan="2" class="question-cell">Dowody/screeny/nagrania</th></tr>
+          <tr><td colspan="2" class="answer-cell">{{ app.data.evidence }}</td></tr>
+          <tr><th colspan="2" class="question-cell">Dodatkowe uwagi</th></tr>
+          <tr><td colspan="2" class="answer-cell">{{ app.data.notes }}</td></tr>
+        </table>
+        <h2>Zgody</h2>
+        <table class="app-table">
+          <tr><th>Oświadczenie o prawdziwości danych</th><td>{{ app.data.consentTruth ? 'Tak' : 'Nie' }}</td></tr>
+          <tr><th>Zapoznanie z regulaminem</th><td>{{ app.data.consentRules ? 'Tak' : 'Nie' }}</td></tr>
         </table>
       </template>
       <template v-else>
@@ -481,7 +516,8 @@ const backPath = computed(() => {
     checker: '/admin/checker-applications',
     moderator: '/admin/moderator-applications',
     administrator: '/admin/administrator-applications',
-    developer: '/admin/developer-applications'
+    developer: '/admin/developer-applications',
+    unban: '/admin/unban'
   }
   const type = (route.meta.type as string) || 'whitelist'
   return map[type] || '/admin/applications'

--- a/src/views/AdminApplications.vue
+++ b/src/views/AdminApplications.vue
@@ -248,7 +248,8 @@ async function openDetail(app: Application) {
     checker: '/admin/checker-applications',
     moderator: '/admin/moderator-applications',
     administrator: '/admin/administrator-applications',
-    developer: '/admin/developer-applications'
+    developer: '/admin/developer-applications',
+    unban: '/admin/unban'
   }
   const typeForDetail = showArchivedOnly.value ? (app.type || 'whitelist') : appType.value
   const prefix = map[typeForDetail] || '/admin/applications'

--- a/src/views/ApplicationStatus.vue
+++ b/src/views/ApplicationStatus.vue
@@ -232,7 +232,9 @@ onMounted(async () => {
             ? 'Twoje podanie na WhiteListCheckera zostało wysłane'
             : appType.value === 'developer'
               ? 'Twoje podanie na Developera zostało wysłane'
-              : 'Twoje podanie zostało Wysłane'
+              : appType.value === 'unban'
+                ? 'Twój wniosek o odbanowanie został wysłany'
+                : 'Twoje podanie zostało Wysłane'
   }
   updateRemaining()
   if (reapplyAfter.value && Date.now() < reapplyAfter.value) {
@@ -276,7 +278,8 @@ function gotoApply() {
       checker: '/apply-checker',
       moderator: '/apply-moderator',
       administrator: '/apply-administrator',
-      developer: '/apply-developer'
+      developer: '/apply-developer',
+      unban: '/apply-unban'
     }
     window.location.href = paths[appType.value] || '/apply'
   }

--- a/src/views/ApplyUnban.vue
+++ b/src/views/ApplyUnban.vue
@@ -1,0 +1,230 @@
+<template>
+  <main class="apply-page" :style="{ backgroundImage: `url(${backgroundImageUrl})` }">
+    <div class="apply-overlay"></div>
+    <div class="apply-container">
+      <h1>Wniosek o odbanowanie</h1>
+      <form @submit.prevent="submitForm" class="app-form">
+        <h2>1. Dane Gracza</h2>
+        <label>
+          Nick Discord + ID
+          <input v-model="form.discord" readonly />
+        </label>
+        <label>
+          SteamID
+          <input v-model="form.steamId" required placeholder="Twoje SteamID np. 110000112345678" />
+        </label>
+        <label>
+          Nick na serwerze w momencie bana
+          <input v-model="form.serverNick" required placeholder="Twój nick na serwerze" />
+        </label>
+        <label>
+          Data bana
+          <input type="date" v-model="form.banDate" required />
+        </label>
+
+        <h2>2. Szczegóły Bana</h2>
+        <label>
+          Kto nałożył bana
+          <input v-model="form.bannedBy" required placeholder="Nick osoby banującej" />
+        </label>
+        <label>
+          Powód bana
+          <textarea v-model="form.banReason" required placeholder="Powód otrzymania bana"></textarea>
+        </label>
+
+        <h2>3. Wyjaśnienie</h2>
+        <label>
+          Twoja wersja wydarzeń
+          <textarea v-model="form.events" required placeholder="Opisz sytuację swoimi słowami"></textarea>
+        </label>
+        <label>
+          Czy przyznajesz się do złamania zasad?
+          <textarea v-model="form.admit" placeholder="tak / nie + uzasadnienie"></textarea>
+        </label>
+        <label>
+          Co zmieniło się od momentu bana?
+          <textarea v-model="form.change" placeholder="Czy coś zrozumiałeś, poprawiłeś, wracasz z nowym nastawieniem..."></textarea>
+        </label>
+
+        <h2>4. Dodatki (Opcjonalne)</h2>
+        <label>
+          Dowody/screeny/nagrania
+          <textarea v-model="form.evidence" placeholder="Linki do dowodów lub opis"></textarea>
+        </label>
+        <label>
+          Dodatkowe uwagi
+          <textarea v-model="form.notes" placeholder="Inne informacje dla administracji"></textarea>
+        </label>
+
+        <h2>5. Zgoda i potwierdzenie</h2>
+        <label class="checkbox">
+          <input type="checkbox" v-model="form.consentTruth" required />
+          Oświadczam, że powyższe dane są zgodne z prawdą
+        </label>
+        <label class="checkbox">
+          <input type="checkbox" v-model="form.consentRules" required />
+          Zapoznałem się z regulaminem serwera i odwołania od bana
+        </label>
+        <button type="submit" class="submit-btn">Wyślij podanie</button>
+      </form>
+      <p v-if="success" class="success-message">
+        Twój wniosek o odbanowanie został wysłany. Obecnie twój wniosek ma status: {{ status }}
+      </p>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import backgroundImage from '../assets/background.jpg'
+
+const backgroundImageUrl = ref(backgroundImage)
+const router = useRouter()
+const appType = 'unban'
+const success = ref(false)
+const status = ref('')
+
+interface FormData {
+  discord: string
+  steamId: string
+  serverNick: string
+  banDate: string
+  bannedBy: string
+  banReason: string
+  events: string
+  admit: string
+  change: string
+  evidence: string
+  notes: string
+  consentTruth: boolean
+  consentRules: boolean
+}
+
+const form = ref<FormData>({
+  discord: '',
+  steamId: '',
+  serverNick: '',
+  banDate: '',
+  bannedBy: '',
+  banReason: '',
+  events: '',
+  admit: '',
+  change: '',
+  evidence: '',
+  notes: '',
+  consentTruth: false,
+  consentRules: false
+})
+
+onMounted(async () => {
+  const res = await fetch('/api/user', { credentials: 'include' })
+  const data = await res.json()
+  if (data.user) {
+    form.value.discord = `${data.user.username}#${data.user.id}`
+  }
+  const statusRes = await fetch('/api/status?type=unban', { credentials: 'include' })
+  const statusData = await statusRes.json()
+  if (
+    statusData.status &&
+    (statusData.status !== 'Negatywnie' || (statusData.reapplyAfter && Date.now() < statusData.reapplyAfter))
+  ) {
+    router.push('/status-unban')
+    return
+  }
+})
+
+async function submitForm() {
+  const response = await fetch('/api/apply', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...form.value, type: appType })
+  })
+  if (response.ok) {
+    const data = await response.json()
+    success.value = true
+    status.value = data.status
+    router.push('/status-unban')
+  } else if (response.status === 400) {
+    router.push('/status-unban')
+  }
+}
+</script>
+
+<style scoped>
+.apply-page {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2rem 1rem;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.apply-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 1;
+}
+
+.apply-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+  position: relative;
+  z-index: 2;
+}
+
+.app-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.app-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.app-form input,
+.app-form textarea {
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #444;
+  background: #222;
+  color: #fff;
+}
+
+.app-form textarea {
+  min-height: 80px;
+}
+
+.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.submit-btn {
+  align-self: center;
+  padding: 0.6rem 1.2rem;
+  background: var(--primary);
+  border: none;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.success-message {
+  margin-top: 1rem;
+  color: var(--secondary);
+}
+</style>


### PR DESCRIPTION
## Summary
- implement unban request form and admin panel integration
- add dropdown link for unban requests in header
- register unban routes for users and admins
- support unban type in status page and admin views

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851efcc12348325b4949763d7bc1e62