### PR TITLE
Enhance admin UI and question loading

### DIFF
--- a/database.json
+++ b/database.json
@@ -11,8 +11,10 @@
   },
   "questions": {
     "whitelist": [],
+    "checker": [],
+    "moderator": [],
     "administrator": [],
-    "moderator": []
+    "developer": []
   },
   "changelog": [
     {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -17,6 +17,7 @@ import AdminPlayerNotes from '../views/AdminPlayerNotes.vue'
 import AdminSettings from '../views/AdminSettings.vue'
 import AdminQuestions from '../views/AdminQuestions.vue'
 import AdminChangelog from '../views/AdminChangelog.vue'
+import AdminWitcher from '../views/AdminWitcher.vue'
 import Changelog from '../views/Changelog.vue'
 import DiscordRequired from '../views/DiscordRequired.vue'
 
@@ -363,6 +364,12 @@ const router = createRouter({
         title: 'Notatki o Graczach - AetherRP',
         requiresAuth: true
       }
+    },
+    {
+      path: '/admin/witcher',
+      name: 'admin-witcher',
+      component: AdminWitcher,
+      meta: { title: 'Witcher - AetherRP', requiresAuth: true }
     },
     {
       path: '/admin/settings',

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -48,21 +48,14 @@
           <span>Notatki o graczach</span>
         </RouterLink>
       </div>
-      <div v-if="isWitcher" class="sections">
-        <h2 class="category-title"><i class="fa-solid fa-hat-wizard"></i> Witcher</h2>
-        <RouterLink class="admin-section" to="/admin/settings">
-          <i class="fa-solid fa-gear"></i>
-          <span>Ustawienia</span>
-        </RouterLink>
-        <RouterLink class="admin-section" to="/admin/questions">
-          <i class="fa-solid fa-question"></i>
-          <span>Pytania</span>
-        </RouterLink>
-        <RouterLink class="admin-section" to="/admin/changelog">
-          <i class="fa-solid fa-clock-rotate-left"></i>
-          <span>Changelog</span>
-        </RouterLink>
-      </div>
+      <RouterLink
+        v-if="isWitcher"
+        class="admin-section"
+        to="/admin/witcher"
+      >
+        <i class="fa-solid fa-hat-wizard"></i>
+        <span>Witcher</span>
+      </RouterLink>
       <div class="admin-extra">
         <RouterLink class="admin-section" to="/admin/archived">
           <i class="fa-solid fa-box-archive"></i>
@@ -77,11 +70,13 @@
       </div>
     </div>
   </main>
+  <Footer />
 </template>
 
 <script setup lang="ts">
 import { onMounted, ref, computed } from 'vue'
 import { RouterLink } from 'vue-router'
+import Footer from '../components/Footer.vue'
 
 const roles = ref<string[]>([])
 
@@ -144,7 +139,9 @@ const canViewDeveloper = computed(
     hasRole(ROLE_IDS.WITCHER)
 )
 
-const isWitcher = computed(() => hasRole(ROLE_IDS.WITCHER))
+const isWitcher = computed(
+  () => hasRole(ROLE_IDS.WITCHER) || hasRole(ROLE_IDS.OWNER)
+)
 </script>
 
 <style scoped>

--- a/src/views/AdminChangelog.vue
+++ b/src/views/AdminChangelog.vue
@@ -9,20 +9,22 @@
         <div class="flex gap-2 mb-2">
           <input v-model="entry.date" type="date" class="input" />
           <input v-model="entry.title" placeholder="Tytuł" class="flex-1 input" />
-          <button class="delete-btn" @click="remove(idx)"><i class="fa-solid fa-trash"></i> Usuń</button>
+          <button class="delete-btn" @click="remove(idx)">🗑️ Usuń</button>
         </div>
         <textarea v-model="entry.description" class="textarea"></textarea>
       </div>
     </div>
     <div class="actions">
-      <button class="add-btn" @click="add"><i class="fa-solid fa-plus"></i> Dodaj</button>
-      <button class="save-btn" @click="save"><i class="fa-solid fa-floppy-disk"></i> Zapisz</button>
+      <button class="add-btn" @click="add">➕ Dodaj</button>
+      <button class="save-btn" @click="save">💾 Zapisz</button>
     </div>
+    <Footer />
   </main>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import Footer from '../components/Footer.vue'
 
 interface Entry { date: string; title: string; description: string }
 const changelog = ref<Entry[]>([])
@@ -63,6 +65,8 @@ async function save() {
   min-height: 100vh;
   background: linear-gradient(135deg, #1b1032 0%, #0a0a1a 100%);
   color: #fff;
+  max-width: 700px;
+  margin: 0 auto;
 }
 .log-item {
   margin-bottom: 1rem;
@@ -73,11 +77,13 @@ async function save() {
 }
 
 .input {
-  @apply bg-white/10 border border-white/20 text-white rounded px-2 py-1;
+  @apply bg-white/10 border border-white/20 rounded px-2 py-1;
+  color: #ccc;
 }
 
 .textarea {
-  @apply bg-white/10 border border-white/20 text-white rounded p-2 w-full;
+  @apply bg-white/10 border border-white/20 rounded p-2 w-full;
+  color: #ccc;
 }
 
 .delete-btn {
@@ -89,11 +95,19 @@ async function save() {
 }
 
 .add-btn {
-  @apply px-4 py-2 rounded text-white bg-purple-600 hover:bg-purple-700 flex items-center gap-1;
+  @apply px-4 py-2 rounded text-white;
+  background: var(--gradient-accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .save-btn {
-  @apply px-4 py-2 rounded text-white bg-cyan-600 hover:bg-cyan-700 flex items-center gap-1;
+  @apply px-4 py-2 rounded text-white;
+  background: var(--gradient-accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .back-link {
@@ -111,5 +125,9 @@ async function save() {
 .page-title {
   font-size: 1.5rem;
   margin-bottom: 1rem;
+  background: var(--gradient-accent);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 </style>

--- a/src/views/AdminQuestions.vue
+++ b/src/views/AdminQuestions.vue
@@ -12,12 +12,14 @@
       <option value="developer">Developer</option>
     </select>
     <textarea v-model="text" rows="10" class="textarea"></textarea>
-    <button class="save-btn" @click="save"><i class="fa-solid fa-floppy-disk"></i> Zapisz</button>
+    <button class="save-btn" @click="save">💾 Zapisz</button>
+    <Footer />
   </main>
 </template>
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import Footer from '../components/Footer.vue'
 
 const section = ref('whitelist')
 const text = ref('')
@@ -74,18 +76,25 @@ textarea {
 
 .page-title {
   font-size: 1.5rem;
+  background: var(--gradient-accent);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .select {
-  @apply bg-white/10 border border-white/20 text-white rounded p-2;
+  @apply bg-white/10 border border-white/20 rounded p-2;
+  color: #ccc;
 }
 
 .textarea {
-  @apply bg-white/10 border border-white/20 text-white rounded p-2;
+  @apply bg-white/10 border border-white/20 rounded p-2;
+  color: #ccc;
 }
 
 .save-btn {
-  @apply mt-2 px-4 py-2 rounded text-white bg-gradient-to-r from-purple-600 to-cyan-500;
+  @apply mt-2 px-4 py-2 rounded text-white;
+  background: var(--gradient-accent);
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -15,13 +15,15 @@
           required
         />
       </div>
-      <button class="save-btn" @click="save"><i class="fa-solid fa-floppy-disk"></i> Zapisz</button>
+      <button class="save-btn" @click="save">💾 Zapisz</button>
     </div>
+    <Footer />
   </main>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import Footer from '../components/Footer.vue'
 
 const labels: Record<string, string> = {
   REAPPLY_COOLDOWN_HOURS: 'Czas ponownego zgłoszenia (godz.)',
@@ -90,6 +92,10 @@ async function save() {
 .page-title {
   font-size: 1.5rem;
   margin-bottom: 1rem;
+  background: var(--gradient-accent);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .label {
@@ -97,11 +103,13 @@ async function save() {
 }
 
 .input {
-  @apply bg-white/10 border border-white/20 rounded px-2 py-1 text-white w-24;
+  @apply bg-white/10 border border-white/20 rounded px-2 py-1 w-24;
+  color: #ccc;
 }
 
 .save-btn {
-  @apply mt-4 px-4 py-2 rounded text-white bg-gradient-to-r from-purple-600 to-cyan-500;
+  @apply mt-4 px-4 py-2 rounded text-white;
+  background: var(--gradient-accent);
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;

--- a/src/views/AdminWitcher.vue
+++ b/src/views/AdminWitcher.vue
@@ -1,0 +1,88 @@
+<template>
+  <main class="witcher-page">
+    <RouterLink to="/admin" class="back-link">
+      <i class="fa-solid fa-arrow-left"></i> Powrót
+    </RouterLink>
+    <h1 class="page-title">Witcher</h1>
+    <div class="sections">
+      <RouterLink class="admin-section" to="/admin/settings">
+        <i class="fa-solid fa-gear"></i>
+        <span>Ustawienia</span>
+      </RouterLink>
+      <RouterLink class="admin-section" to="/admin/questions">
+        <i class="fa-solid fa-question"></i>
+        <span>Pytania</span>
+      </RouterLink>
+      <RouterLink class="admin-section" to="/admin/changelog">
+        <i class="fa-solid fa-clock-rotate-left"></i>
+        <span>Changelog</span>
+      </RouterLink>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+</script>
+
+<style scoped>
+.witcher-page {
+  padding: 2rem;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #1b1032 0%, #0a0a1a 100%);
+  color: #fff;
+}
+.page-title {
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  background: var(--gradient-accent);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.sections {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 500px;
+  margin: 0 auto;
+}
+.admin-section {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.admin-section:hover {
+  transform: scale(1.05);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.6);
+}
+.admin-section i {
+  color: var(--primary);
+}
+.admin-section span {
+  background: var(--gradient-accent);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-bottom: 1rem;
+  padding: 0.3rem 0.6rem;
+  background: var(--gradient-accent);
+  color: #fff;
+  border-radius: 4px;
+  text-decoration: none;
+}
+</style>

--- a/src/views/Apply.vue
+++ b/src/views/Apply.vue
@@ -189,7 +189,7 @@ onMounted(async () => {
   }
 
   // Odbierz przypisane do użytkownika pytania
-  const qRes = await fetch('/api/questions', { credentials: 'include' })
+  const qRes = await fetch(`/api/questions?type=${appType.value}`, { credentials: 'include' })
   const qData = await qRes.json()
   if (Array.isArray(qData.questions)) {
     questions.value = qData.questions

--- a/src/views/ApplyAdministrator.vue
+++ b/src/views/ApplyAdministrator.vue
@@ -128,7 +128,10 @@ onMounted(async () => {
   if (data.user) {
     form.value.discord = `${data.user.username}#${data.user.id}`
   }
-  const shuffled = [...scenarioPool].sort(() => Math.random() - 0.5)
+  const qRes = await fetch('/api/questions?type=administrator', { credentials: 'include' })
+  const qData = await qRes.json()
+  const source = Array.isArray(qData.questions) && qData.questions.length ? qData.questions : scenarioPool
+  const shuffled = [...source].sort(() => Math.random() - 0.5)
   scenarioQuestions.value = shuffled.slice(0, 3)
 
   const statusRes = await fetch('/api/status?type=administrator', {

--- a/src/views/ApplyModerator.vue
+++ b/src/views/ApplyModerator.vue
@@ -171,7 +171,10 @@ onMounted(async () => {
   if (data.user) {
     form.value.discord = `${data.user.username}#${data.user.id}`
   }
-  randomScenario.value = scenarioPool[Math.floor(Math.random() * scenarioPool.length)]
+  const qRes = await fetch('/api/questions?type=moderator', { credentials: 'include' })
+  const qData = await qRes.json()
+  const source = Array.isArray(qData.questions) && qData.questions.length ? qData.questions : scenarioPool
+  randomScenario.value = source[Math.floor(Math.random() * source.length)]
 
   const statusRes = await fetch('/api/status?type=moderator', {
     credentials: 'include'

--- a/src/views/Changelog.vue
+++ b/src/views/Changelog.vue
@@ -1,15 +1,20 @@
 <template>
   <main class="changelog-list">
-    <h1>Changelog</h1>
+    <h1 class="title"><i class="fa-solid fa-rotate"></i> Changelog</h1>
     <div v-for="(c, idx) in changelog" :key="idx" class="entry">
-      <h3>{{ c.date }} - {{ c.title }}</h3>
-      <p>{{ c.description }}</p>
+      <div class="date">{{ c.date }}</div>
+      <div class="details">
+        <h3>{{ c.title }}</h3>
+        <p>{{ c.description }}</p>
+      </div>
     </div>
+    <Footer />
   </main>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import Footer from '../components/Footer.vue'
 
 interface Entry { date: string; title: string; description: string }
 const changelog = ref<Entry[]>([])
@@ -29,8 +34,36 @@ onMounted(async () => {
   min-height: 100vh;
   background: #0a0a0a;
   color: #fff;
+  max-width: 800px;
+  margin: 0 auto;
+}
+.title {
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 2rem;
+  background: var(--gradient-accent);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 .entry {
+  display: flex;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1rem;
+  border-radius: 0.5rem;
   margin-bottom: 1rem;
+}
+.date {
+  width: 110px;
+  flex-shrink: 0;
+  color: #ccc;
+}
+.details h3 {
+  margin: 0 0 0.25rem;
+}
+.details p {
+  margin: 0;
+  color: #ccc;
 }
 </style>


### PR DESCRIPTION
## Summary
- style settings page heading, inputs, and save button
- add footer and improved styles for questions and changelog panels
- create Witcher menu view and route
- support per-application questions in the backend
- load question sets in application forms
- redesign public changelog section

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68521334de8c8325be519c437c812263