### PR TITLE
Polish admin panel and changelog

### DIFF
--- a/questions.json
+++ b/questions.json
@@ -1,0 +1,7 @@
+{
+  "whitelist": [],
+  "checker": [],
+  "moderator": [],
+  "administrator": [],
+  "developer": []
+}

--- a/src/components/ChangelogList.vue
+++ b/src/components/ChangelogList.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="rules-updates" v-if="updates.length" data-aos="fade-up" data-aos-delay="200">
+    <h3 data-aos="fade-right"><i class="fa-solid fa-clock-rotate-left"></i> Recent Updates</h3>
+    <div class="update-list">
+      <div
+        v-for="(u, idx) in updates"
+        :key="idx"
+        class="update-item"
+        :data-aos="'fade-left'"
+        :data-aos-delay="250 + idx * 50"
+      >
+        <div class="update-date">{{ formatDate(u.date) }}</div>
+        <div class="update-content">
+          <h4>{{ u.title }}</h4>
+          <p>{{ u.description }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+interface Entry { date: string; title: string; description: string }
+const updates = ref<Entry[]>([])
+
+onMounted(async () => {
+  const res = await fetch('/api/changelog')
+  if (res.ok) {
+    const data = await res.json()
+    updates.value = data.changelog || []
+  }
+})
+
+function formatDate(d: string) {
+  const dt = new Date(d)
+  return dt.toLocaleDateString()
+}
+</script>
+
+<style scoped>
+.rules-updates {
+  background: rgba(25, 25, 25, 0.6);
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  margin: 60px 0;
+  padding: 30px;
+}
+
+.rules-updates h3 {
+  margin: 0 0 25px;
+  font-size: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.rules-updates h3 i {
+  color: #8A2BE2;
+}
+
+.update-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.update-item {
+  display: flex;
+  gap: 20px;
+  position: relative;
+  padding-left: 20px;
+}
+
+.update-item::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 3px;
+  background: linear-gradient(to bottom, #8A2BE2, transparent);
+}
+
+.update-date {
+  font-weight: 600;
+  flex-basis: 120px;
+  flex-shrink: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.update-content h4 {
+  margin: 0 0 8px;
+  font-size: 1.1rem;
+}
+
+.update-content p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+</style>

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -47,15 +47,15 @@
           <i class="fa-solid fa-note-sticky"></i>
           <span>Notatki o graczach</span>
         </RouterLink>
+        <RouterLink
+          v-if="isWitcher"
+          class="admin-section"
+          to="/admin/witcher"
+        >
+          <i class="fa-solid fa-hat-wizard"></i>
+          <span>Witcher</span>
+        </RouterLink>
       </div>
-      <RouterLink
-        v-if="isWitcher"
-        class="admin-section"
-        to="/admin/witcher"
-      >
-        <i class="fa-solid fa-hat-wizard"></i>
-        <span>Witcher</span>
-      </RouterLink>
       <div class="admin-extra">
         <RouterLink class="admin-section" to="/admin/archived">
           <i class="fa-solid fa-box-archive"></i>
@@ -70,13 +70,11 @@
       </div>
     </div>
   </main>
-  <Footer />
 </template>
 
 <script setup lang="ts">
 import { onMounted, ref, computed } from 'vue'
 import { RouterLink } from 'vue-router'
-import Footer from '../components/Footer.vue'
 
 const roles = ref<string[]>([])
 

--- a/src/views/AdminApplicationDetail.vue
+++ b/src/views/AdminApplicationDetail.vue
@@ -743,6 +743,10 @@ const decisionInfo = computed(() => {
 .detail-container {
   max-width: 800px;
   margin: 0 auto;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 1rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.5);
 }
 
 .app-table {
@@ -790,6 +794,15 @@ const decisionInfo = computed(() => {
   min-height: 80px;
   border-radius: 6px;
   padding: 0.4rem;
+}
+
+#status-select {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #ccc;
+  border-radius: 6px;
+  padding: 0.4rem;
+  width: 100%;
 }
 .update-msg {
   color: #00ff7f;

--- a/src/views/AdminApplications.vue
+++ b/src/views/AdminApplications.vue
@@ -290,16 +290,14 @@ async function archiveApplication(app: Application) {
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
-
 .status-columns {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1rem;
-  overflow-x: auto;
   margin-top: 1rem;
 }
 
 .status-column {
-  flex: 1;
   min-width: 220px;
 }
 

--- a/src/views/AdminChangelog.vue
+++ b/src/views/AdminChangelog.vue
@@ -9,22 +9,26 @@
         <div class="flex gap-2 mb-2">
           <input v-model="entry.date" type="date" class="input" />
           <input v-model="entry.title" placeholder="Tytuł" class="flex-1 input" />
-          <button class="delete-btn" @click="remove(idx)">🗑️ Usuń</button>
+          <button class="delete-btn" @click="remove(idx)">
+            <i class="fa-solid fa-trash"></i> Usuń
+          </button>
         </div>
         <textarea v-model="entry.description" class="textarea"></textarea>
       </div>
     </div>
     <div class="actions">
-      <button class="add-btn" @click="add">➕ Dodaj</button>
-      <button class="save-btn" @click="save">💾 Zapisz</button>
+      <button class="add-btn" @click="add">
+        <i class="fa-solid fa-plus"></i> Dodaj
+      </button>
+      <button class="save-btn" @click="save">
+        <i class="fa-solid fa-floppy-disk"></i> Zapisz
+      </button>
     </div>
-    <Footer />
   </main>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import Footer from '../components/Footer.vue'
 
 interface Entry { date: string; title: string; description: string }
 const changelog = ref<Entry[]>([])
@@ -78,12 +82,12 @@ async function save() {
 
 .input {
   @apply bg-white/10 border border-white/20 rounded px-2 py-1;
-  color: #ccc;
+  color: #fff;
 }
 
 .textarea {
   @apply bg-white/10 border border-white/20 rounded p-2 w-full;
-  color: #ccc;
+  color: #fff;
 }
 
 .delete-btn {
@@ -91,7 +95,7 @@ async function save() {
 }
 
 .actions {
-  @apply mt-4 flex gap-2;
+  @apply mt-4 flex gap-2 justify-center;
 }
 
 .add-btn {
@@ -109,6 +113,7 @@ async function save() {
   align-items: center;
   gap: 0.5rem;
 }
+
 
 .back-link {
   display: inline-flex;

--- a/src/views/AdminQuestions.vue
+++ b/src/views/AdminQuestions.vue
@@ -13,13 +13,11 @@
     </select>
     <textarea v-model="text" rows="10" class="textarea"></textarea>
     <button class="save-btn" @click="save">💾 Zapisz</button>
-    <Footer />
   </main>
 </template>
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import Footer from '../components/Footer.vue'
 
 const section = ref('whitelist')
 const text = ref('')
@@ -84,12 +82,12 @@ textarea {
 
 .select {
   @apply bg-white/10 border border-white/20 rounded p-2;
-  color: #ccc;
+  color: #fff;
 }
 
 .textarea {
   @apply bg-white/10 border border-white/20 rounded p-2;
-  color: #ccc;
+  color: #fff;
 }
 
 .save-btn {
@@ -98,5 +96,6 @@ textarea {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  margin: 0 auto;
 }
 </style>

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -17,13 +17,11 @@
       </div>
       <button class="save-btn" @click="save">💾 Zapisz</button>
     </div>
-    <Footer />
   </main>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import Footer from '../components/Footer.vue'
 
 const labels: Record<string, string> = {
   REAPPLY_COOLDOWN_HOURS: 'Czas ponownego zgłoszenia (godz.)',
@@ -104,7 +102,7 @@ async function save() {
 
 .input {
   @apply bg-white/10 border border-white/20 rounded px-2 py-1 w-24;
-  color: #ccc;
+  color: #fff;
 }
 
 .save-btn {
@@ -113,5 +111,6 @@ async function save() {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  margin: 0 auto;
 }
 </style>

--- a/src/views/Changelog.vue
+++ b/src/views/Changelog.vue
@@ -1,69 +1,34 @@
 <template>
-  <main class="changelog-list">
-    <h1 class="title"><i class="fa-solid fa-rotate"></i> Changelog</h1>
-    <div v-for="(c, idx) in changelog" :key="idx" class="entry">
-      <div class="date">{{ c.date }}</div>
-      <div class="details">
-        <h3>{{ c.title }}</h3>
-        <p>{{ c.description }}</p>
-      </div>
+  <main class="rules-page">
+    <div class="container">
+      <h1 data-aos="fade-right" class="page-title">
+        <i class="fa-solid fa-clock-rotate-left"></i> Changelog
+      </h1>
+      <ChangelogList />
     </div>
-    <Footer />
   </main>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import Footer from '../components/Footer.vue'
-
-interface Entry { date: string; title: string; description: string }
-const changelog = ref<Entry[]>([])
-
-onMounted(async () => {
-  const res = await fetch('/api/changelog')
-  if (res.ok) {
-    const data = await res.json()
-    changelog.value = data.changelog || []
-  }
-})
+import ChangelogList from '../components/ChangelogList.vue'
 </script>
 
 <style scoped>
-.changelog-list {
-  padding: 2rem;
-  min-height: 100vh;
-  background: #0a0a0a;
-  color: #fff;
-  max-width: 800px;
-  margin: 0 auto;
-}
-.title {
-  text-align: center;
+.page-title {
   font-size: 2rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   background: var(--gradient-accent);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
-.entry {
-  display: flex;
-  gap: 1rem;
-  background: rgba(255, 255, 255, 0.05);
-  padding: 1rem;
-  border-radius: 0.5rem;
-  margin-bottom: 1rem;
-}
-.date {
-  width: 110px;
-  flex-shrink: 0;
-  color: #ccc;
-}
-.details h3 {
-  margin: 0 0 0.25rem;
-}
-.details p {
-  margin: 0;
-  color: #ccc;
+.rules-page {
+  padding: 2rem;
+  min-height: 100vh;
+  background: #0a0a0a;
+  color: #fff;
 }
 </style>

--- a/src/views/Rules.vue
+++ b/src/views/Rules.vue
@@ -96,8 +96,8 @@
 </template>
 
 <script setup lang="ts">
-import Footer from '../components/Footer.vue';
 import { ref, onMounted, onUnmounted } from 'vue';
+import Footer from '../components/Footer.vue';
 import AOS from 'aos';
 
 // 返回顶部按钮状态


### PR DESCRIPTION
## Summary
- style admin application columns with responsive grid
- tweak application detail view and status dropdown colors
- move Witcher tile to main admin section
- style settings and questions pages consistently
- redesign admin changelog buttons and inputs
- build new changelog component and page
- store questions in `questions.json`
- remove footer from subpages
- restore footer on main pages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685218e5fd14832588a7c2fb2ecf6045