### PR TITLE
Add placeholder hints to staff applications

### DIFF
--- a/src/views/ApplyAdministrator.vue
+++ b/src/views/ApplyAdministrator.vue
@@ -13,31 +13,55 @@
         <h2>2. Doświadczenie i obowiązki</h2>
         <label>
           Czy byłeś wcześniej adminem na serwerze RP lub społecznościowym?
-          <textarea v-model="form.previousAdmin" required></textarea>
+          <textarea
+            v-model="form.previousAdmin"
+            required
+            placeholder="Opisz swoje wcześniejsze doświadczenia"
+          ></textarea>
         </label>
         <label>
           Jakie obszary administracyjne Cię interesują?
-          <textarea v-model="form.adminAreas" required></textarea>
+          <textarea
+            v-model="form.adminAreas"
+            required
+            placeholder="Napisz czym chciałbyś się zajmować"
+          ></textarea>
         </label>
 
         <h2>3. 🎲 Sytuacje organizacyjne</h2>
         <div v-for="(q, i) in scenarioQuestions" :key="i" class="question-block">
           <p class="question">{{ q }}</p>
-          <textarea v-model="form.scenarios[i]" required></textarea>
+          <textarea
+            v-model="form.scenarios[i]"
+            required
+            placeholder="Twoja odpowiedź na pytanie"
+          ></textarea>
         </div>
 
         <h2>4. Zarządzanie</h2>
         <label>
           Co to jest zdrowa struktura administracyjna?
-          <textarea v-model="form.healthyStructure" required></textarea>
+          <textarea
+            v-model="form.healthyStructure"
+            required
+            placeholder="Jak rozumiesz dobrą organizację?"
+          ></textarea>
         </label>
         <label>
           Czy jesteś skory do współpracy z rolami wyżej? Jak to sobie wyobrażasz?
-          <textarea v-model="form.cooperation" required></textarea>
+          <textarea
+            v-model="form.cooperation"
+            required
+            placeholder="Opisz swoją gotowość do współpracy"
+          ></textarea>
         </label>
         <label>
           Co Twoim zdaniem warto byłoby usprawnić w administracji?
-          <textarea v-model="form.improvements" required></textarea>
+          <textarea
+            v-model="form.improvements"
+            required
+            placeholder="Twoje pomysły na ulepszenia"
+          ></textarea>
         </label>
 
         <h2>5. Zgody</h2>

--- a/src/views/ApplyChecker.vue
+++ b/src/views/ApplyChecker.vue
@@ -11,39 +11,71 @@
         </label>
         <label>
           Od jak dawna jesteś na naszym serwerze?
-          <input v-model="form.serverTime" required />
+          <input
+            v-model="form.serverTime"
+            required
+            placeholder="Np. od 3 miesięcy"
+          />
         </label>
 
         <h2>2. Doświadczenie i podejście</h2>
         <label>
           Czy miałeś styczność z weryfikacją lub selekcją graczy?
-          <textarea v-model="form.verificationExp" required></textarea>
+          <textarea
+            v-model="form.verificationExp"
+            required
+            placeholder="Opisz swoje wcześniejsze doświadczenia"
+          ></textarea>
         </label>
         <label>
           Jak rozpoznać gracza, który "tylko wypełnił, żeby wejść", od gracza z potencjałem?
-          <textarea v-model="form.differentiate" required></textarea>
+          <textarea
+            v-model="form.differentiate"
+            required
+            placeholder="Wyjaśnij swoje kryteria oceny"
+          ></textarea>
         </label>
         <label>
           Na co zwracasz uwagę przy czytaniu podania na WL?
-          <textarea v-model="form.reviewFocus" required></textarea>
+          <textarea
+            v-model="form.reviewFocus"
+            required
+            placeholder="Wymień najważniejsze elementy"
+          ></textarea>
         </label>
         <label>
           Co Twoim zdaniem oznacza dobre RP i jakbyś je promował?
-          <textarea v-model="form.goodRp" required></textarea>
+          <textarea
+            v-model="form.goodRp"
+            required
+            placeholder="Twoja definicja dobrego RP"
+          ></textarea>
         </label>
 
         <h2>3. Praca</h2>
         <label>
           Ile podań jesteś w stanie realnie sprawdzić dziennie / tygodniowo?
-          <input v-model="form.workload" required />
+          <input
+            v-model="form.workload"
+            required
+            placeholder="Np. 5 dziennie lub 20 tygodniowo"
+          />
         </label>
         <label>
           Co robisz, jeśli masz wątpliwości co do kandydata?
-          <textarea v-model="form.doubts" required></textarea>
+          <textarea
+            v-model="form.doubts"
+            required
+            placeholder="Opisz swoje działania w takiej sytuacji"
+          ></textarea>
         </label>
         <label>
           Wolisz działać samodzielnie czy w parze z innym Checkerem?
-          <input v-model="form.teamwork" required />
+          <input
+            v-model="form.teamwork"
+            required
+            placeholder="Opisz preferowany styl pracy"
+          />
         </label>
 
         <h2>4. Zgody</h2>

--- a/src/views/ApplyDeveloper.vue
+++ b/src/views/ApplyDeveloper.vue
@@ -13,39 +13,75 @@
         <h2>2. Doświadczenie i umiejętności</h2>
         <label>
           Jakie języki programowania znasz?
-          <textarea v-model="form.languages" required></textarea>
+          <textarea
+            v-model="form.languages"
+            required
+            placeholder="Wypisz języki, w których się czujesz najlepiej"
+          ></textarea>
         </label>
         <label>
           Czy pracowałeś wcześniej z zasobami FiveM? Jakimi?
-          <textarea v-model="form.fivemExp" required></textarea>
+          <textarea
+            v-model="form.fivemExp"
+            required
+            placeholder="Opisz swoje doświadczenie z FiveM"
+          ></textarea>
         </label>
         <label>
           Jak wygląda Twoja organizacja pracy przy większych zadaniach?
-          <textarea v-model="form.workOrg" required></textarea>
+          <textarea
+            v-model="form.workOrg"
+            required
+            placeholder="Przedstaw swój sposób planowania"
+          ></textarea>
         </label>
         <label>
           Opisz projekt/skrypt, z którego jesteś najbardziej dumny/a.
-          <textarea v-model="form.proudProject" required></textarea>
+          <textarea
+            v-model="form.proudProject"
+            required
+            placeholder="Krótki opis najciekawszego projektu"
+          ></textarea>
         </label>
         <label>
           Jak reagujesz, gdy ktoś zgłasza błąd w Twoim kodzie?
-          <textarea v-model="form.bugResponse" required></textarea>
+          <textarea
+            v-model="form.bugResponse"
+            required
+            placeholder="Opisz swoje podejście do poprawek"
+          ></textarea>
         </label>
         <label>
           Czy potrafisz kodować pod cudze wymagania?
-          <textarea v-model="form.requirements" required></textarea>
+          <textarea
+            v-model="form.requirements"
+            required
+            placeholder="Jak pracujesz według specyfikacji?"
+          ></textarea>
         </label>
         <label>
           Jakie obszary Cię najbardziej interesują? (UI, systemy RP, joby, zasoby)
-          <textarea v-model="form.interests" required></textarea>
+          <textarea
+            v-model="form.interests"
+            required
+            placeholder="Wymień preferowane dziedziny"
+          ></textarea>
         </label>
         <label>
           Czy potrafisz przeprowadzać testy jednostkowe i techniczne?
-          <textarea v-model="form.testing" required></textarea>
+          <textarea
+            v-model="form.testing"
+            required
+            placeholder="Opisz swoje doświadczenia z testowaniem"
+          ></textarea>
         </label>
         <label>
           🔗 Link do portfolio (GitHub, Discord bot, skrypt, demo)
-          <input v-model="form.portfolio" required />
+          <input
+            v-model="form.portfolio"
+            required
+            placeholder="https://github.com/twoj_projekt"
+          />
         </label>
 
         <h2>3. Zgody</h2>

--- a/src/views/ApplyModerator.vue
+++ b/src/views/ApplyModerator.vue
@@ -11,62 +11,115 @@
         </label>
         <label>
           Wiek
-          <input type="number" v-model.number="form.age" required />
+          <input
+            type="number"
+            v-model.number="form.age"
+            required
+            placeholder="Podaj swój wiek"
+          />
         </label>
         <label>
           Od jak dawna jesteś na serwerze?
-          <input v-model="form.serverTime" required />
+          <input
+            v-model="form.serverTime"
+            required
+            placeholder="Np. od pół roku"
+          />
         </label>
         <label>
           Ile czasu dziennie jesteś aktywny/a na Discordzie?
-          <input v-model="form.activeTime" required />
+          <input
+            v-model="form.activeTime"
+            required
+            placeholder="Przykład: 3-4h dziennie"
+          />
         </label>
 
         <h2>2. Doświadczenie i podejście</h2>
         <label>
           Czy pełniłaś/eś wcześniej funkcję moderatora? Gdzie i jak wyglądała ta rola?
-          <textarea v-model="form.moderatorExp" required></textarea>
+          <textarea
+            v-model="form.moderatorExp"
+            required
+            placeholder="Opisz swoje wcześniejsze doświadczenie"
+          ></textarea>
         </label>
         <label>
           Dlaczego chcesz zostać Moderatorem u nas?
-          <textarea v-model="form.motivation" required></textarea>
+          <textarea
+            v-model="form.motivation"
+            required
+            placeholder="Napisz co Cię motywuje"
+          ></textarea>
         </label>
         <label>
           Jakie są Twoje mocne strony w kontakcie z ludźmi?
-          <textarea v-model="form.strengths" required></textarea>
+          <textarea
+            v-model="form.strengths"
+            required
+            placeholder="Wymień swoje atuty"
+          ></textarea>
         </label>
 
         <h2>3. Sytuacje i zachowanie</h2>
         <label>
           Jak reagujesz, gdy użytkownik prowokuje innych, ale nie łamie regulaminu bezpośrednio?
-          <textarea v-model="form.provocation" required></textarea>
+          <textarea
+            v-model="form.provocation"
+            required
+            placeholder="Opisz swoje podejście do takiej sytuacji"
+          ></textarea>
         </label>
         <label>
           Co robisz, jeśli ktoś wysyła zgłoszenie w stylu \"XD lol\" – bez konkretów?
-          <textarea v-model="form.lolReport" required></textarea>
+          <textarea
+            v-model="form.lolReport"
+            required
+            placeholder="Twój sposób postępowania"
+          ></textarea>
         </label>
         <label>
           Jak rozpoznać, że zgłoszenie nie jest trollowaniem, tylko realnym problemem?
-          <textarea v-model="form.realProblem" required></textarea>
+          <textarea
+            v-model="form.realProblem"
+            required
+            placeholder="Na co zwracasz uwagę?"
+          ></textarea>
         </label>
         <div class="question-block">
           <p class="question">🎲 PYTANIE LOSOWE</p>
           <p>{{ randomScenario }}</p>
-          <textarea v-model="form.randomAnswer" required></textarea>
+          <textarea
+            v-model="form.randomAnswer"
+            required
+            placeholder="Twoja reakcja na opisany scenariusz"
+          ></textarea>
         </div>
 
         <h2>4. Praca w zespole</h2>
         <label>
           Jak widzisz współpracę z innymi członkami zespołu, takimi jak Community Manager, Admin czy Developer?
-          <textarea v-model="form.teamwork" required></textarea>
+          <textarea
+            v-model="form.teamwork"
+            required
+            placeholder="Opisz swoje podejście do pracy w zespole"
+          ></textarea>
         </label>
         <label>
           Jak rozumiesz swoją rolę w przekazywaniu zgłoszeń dalej? Kiedy decydujesz się rozwiązać coś samodzielnie, a kiedy informujesz innych członków zespołu?
-          <textarea v-model="form.escalation" required></textarea>
+          <textarea
+            v-model="form.escalation"
+            required
+            placeholder="Wyjaśnij swoją strategię"
+          ></textarea>
         </label>
         <label>
           Czy potrafisz pozostać neutralny, nawet gdy temat dotyczy znajomej osoby?
-          <textarea v-model="form.neutrality" required></textarea>
+          <textarea
+            v-model="form.neutrality"
+            required
+            placeholder="Opisz jak zachowujesz bezstronność"
+          ></textarea>
         </label>
 
         <h2>5. Zgody</h2>


### PR DESCRIPTION
## Summary
- add field placeholders for WhiteListChecker form
- add field placeholders for Moderator form
- add field placeholders for Administrator form
- add field placeholders for Developer form

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854a69057208325bd309d4136282edd